### PR TITLE
Fix: change directory to be used as a flag and not command line arguments 

### DIFF
--- a/env0.plugin.yml
+++ b/env0.plugin.yml
@@ -20,4 +20,4 @@ run:
     curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | sed 's/unzip -u/unzip -o/' | bash
     
     tflint --init
-    tflint ${inputs.flags} ${inputs.directory}
+    tflint ${inputs.flags} --chdir=${inputs.directory}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Since [v0.44.0](https://github.com/terraform-linters/tflint/releases/tag/v0.44.0) tflint supports `--chdir` arg to input the directory.
In [v0.47.0](https://github.com/terraform-linters/tflint/releases/tag/v0.47.0) it got deprecated.

So the plugin's users aren't able to use a more upgraded version.

### Solution
use the flag `--chdir`

❗ this requires the plugin's users to use a minimum version of 0.44.0 which is reasonable given the fact we created it after the `v0.44.0` was introduced

### How I _manually_ verified it works
- [x] ran it and verify it works with v0.50.3 (latest), v0.47.0, v.0.46.0