### PR TITLE
Chore: Retry tflint download

### DIFF
--- a/env0.plugin.yml
+++ b/env0.plugin.yml
@@ -29,7 +29,7 @@ run:
     echo "Flags: ${TFLINT_FLAGS}"
   
     mkdir -p "${TFLINT_INSTALL_PATH}"
-    curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | sed 's/unzip -u/unzip -o/' | bash
+    curl --retry 5 --retry-all-errors -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | sed 's/unzip -u/unzip -o/' | bash
     
     tflint --init
 


### PR DESCRIPTION
Got this error when trying to download tflint:
```
curl: (56) Recv failure: Connection reset by peer
```

Added retry mechanism to make it more resilient